### PR TITLE
Update hamburger icon

### DIFF
--- a/svg/hamburger.svg
+++ b/svg/hamburger.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1024" height="1024" viewBox="0 0 1024 1024"><path d="M225 460h576v96H225zM225 620h576v96H225zM225 300h576v96H225z"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="1024" height="1024" viewBox="0 0 1024 1024"><path d="M224 304h576v66H224zM224 479h576v66H224zM224 654h576v66H224z"/></svg>


### PR DESCRIPTION
The previous icon looked thicker (even though it wasn't) because of the whitespace
between the lines. This commit slims the lines down.