### PR TITLE
Remove bit about gulp which we don't do anymore

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -40,15 +40,23 @@ If you want to add or update an icon, please open a pull request, making sure th
 
 If your icon meets the design and technical criteria please follow the following steps and then open a Pull Request:
 
-1. Clone the repository and install dependencies:
+1. Clone the repository
 
 		git clone https://github.com/Financial-Times/fticons.git
 		cd fticons
 
+1. Create a branch
+		
+		git checkout -b add-new-icon
+		
 1. Add or edit an SVG file to the `svg` folder.
-1. Rebuild the imageList.json so people can see the demos over on http://registry.origami.ft.com/components/fticons. You will need gulp to be installed to do this, then you can run:
+1. Commit your changes
 
-		gulp
+		git add /svg/your-new-icon.svg
+		git commit -m "Added new pathfinder icon"
+		git push origin add-new-icon
+	
+1. Go to Github and open a pull request
 
 ## Removing an icon
 


### PR DESCRIPTION
**Description:**


**Checklist:**

|Requirement| Completed?|
|---|---|
|Icons must be a single colour (black)| |
|Icons must be square| |
|Icons must meet a need that is not already met by a pre-existing icon| |
|Icons should be suitable for reuse in more than 1 application| |
|Icons should align to a 40x40 pixel grid, with 10px padding on each side| |
|Icons should be a solid shape rather than outlines where possible| |
|Icons should have a minimum line thickness of 2px (including negative space thickness)| |
|Icons should have square rather than rounded corners where suitable| |
|Icons must be SVG v1.1| |
|Icons must not contain any ClipPaths. This is because the conversion of SVG to PNG in v1 of the Image Service does not work if ClipPaths are present.| |
|Icons must have been run through an SVG compression service (such as SVGOMG)| |
|Icons must have been tested with the Responsive Image Service's SVG -> PNG conversion. | |
|Icons must have been tested with the Image Service's tinting option. How do I do this?| |
|Icons should have a bounding box of 1024. This is because of a quirk with both versions of the Image Service, whereby a conversion from SVG to PNG will be very blurry if the source SVG has a small viewBox.| |

|Testing PNG conversion using Origami Image Service:| Completed?|
|---|---|
|v1| |
|v2| |

|Testing PNG + resizing using Origami Image Service:| Completed?|
|---|---|
|v1| |
|v2| |

|Testing tinting using Origami Image Service:| Completed?|
|---|---|
|v1| |
|v2| |
