### PR TITLE
Remove reference to old image service

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -21,8 +21,7 @@
 - [ ] Icon names must include the .svg file extension
 
 
-|Testing PNG conversion using Origami Image Service: Completed?
-|---|---|
+Testing PNG conversion using Origami Image Service: Completed?
 - [ ] v1
 - [ ] v2
 
@@ -30,6 +29,6 @@ Testing PNG + resizing using Origami Image Service: Completed?
 - [ ] v1
 - [ ] v2
 
-|Testing tinting using Origami Image Service: Completed?
+Testing tinting using Origami Image Service: Completed?
 - [ ] v1
 - [ ] v2

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,23 +12,21 @@
 - [ ] Icons should have a minimum line thickness of 2px (including negative space thickness)
 - [ ] Icons should have square rather than rounded corners where suitable
 - [ ] Icons must be SVG v1.1
-- [ ] Icons must not contain any ClipPaths. This is because the conversion of SVG to PNG in v1 of the Image Service does not work if ClipPaths are present.
 - [ ] Icons must have been run through an SVG compression service (such as SVGOMG)
 - [ ] Icons must have been tested with the Responsive Image Service's SVG -> PNG conversion.
-- [ ] Icons must have been tested with the Image Service's tinting option. How do I do this?
-- [ ] Icons should have a bounding box of 1024. This is because of a quirk with both versions of the Image Service, whereby a conversion from SVG to PNG will be very blurry if the source SVG has a small viewBox.
+- [ ] Icons must have been tested with the Image Service's tinting option.
+- [ ] Icons should have a bounding box of 1024.
 - [ ] Icon names must be made up only of lowecase a-z, or a hyphen
 - [ ] Icon names must include the .svg file extension
 
+---
 
-Testing PNG conversion using Origami Image Service: Completed?
-- [ ] v1
-- [ ] v2
+- [ ] Testing PNG conversion using Origami Image Service
 
-Testing PNG + resizing using Origami Image Service: Completed?
-- [ ] v1
-- [ ] v2
+---
 
-Testing tinting using Origami Image Service: Completed?
-- [ ] v1
-- [ ] v2
+- [ ] Testing PNG + resizing using Origami Image Service
+
+---
+
+- [ ] Testing tinting using Origami Image Service

--- a/contributing.md
+++ b/contributing.md
@@ -65,19 +65,16 @@ A lot of people use fticons in different ways. To remove an icon completely from
 ## How to test an icon with the Image Service
 
 The Image Service has some quirks, so new SVG icons should be tested with it before shipping.
-While v1 and v2 of the Image Service are running concurrently, you should test with both. The following requests cover all known quirks with SVGs.
+The following requests cover all known quirks with SVGs.
 
 ### Testing PNG conversion
 
-- v1: `https://image.webservices.ft.com/v1/images/raw/{http://path-to-image.svg}?source=test&format=png`
-- v2: `https://www.ft.com/__origami/service/image/v2/images/raw/{http://path-to-image.svg}?source=test&format=png`
+- `https://www.ft.com/__origami/service/image/v2/images/raw/{http://path-to-image.svg}?source=test&format=png`
 
 ### Testing PNG + resizing
 
-- v1: `https://image.webservices.ft.com/v1/images/raw/{http://path-to-image.svg}?source=test&format=png&width=400`
-- v2: `https://www.ft.com/__origami/service/image/v2/images/raw/{http://path-to-image.svg}?source=test&format=png&width=400`
+- `https://www.ft.com/__origami/service/image/v2/images/raw/{http://path-to-image.svg}?source=test&format=png&width=400`
 
 ### Testing tinting
 
-- v1: `https://image.webservices.ft.com/v1/images/raw/{http://path-to-image.svg}?source=test&tint=00ff00,00ff00`
-- v2: `https://www.ft.com/__origami/service/image/v2/images/raw/{http://path-to-image.svg}?source=test&tint=00ff00`
+- `https://www.ft.com/__origami/service/image/v2/images/raw/{http://path-to-image.svg}?source=test&tint=00ff00`

--- a/contributing.md
+++ b/contributing.md
@@ -21,11 +21,11 @@ If you want to add or update an icon, please open a pull request, making sure th
 ### Technical:
 
 1. Icons must be SVG v1.1
-1. Icons must not contain any ClipPaths. This is because the conversion of SVG to PNG in v1 of the Image Service does not work if ClipPaths are present.
+1. Icons must not contain any ClipPaths.
 1. Icons must have been run through an SVG compression service (such as [SVGOMG](https://jakearchibald.github.io/svgomg/))
 1. Icons must have been tested with the [Responsive Image Service](https://www.ft.com/__origami/service/image/v2/docs/url-builder)'s SVG -> PNG conversion. [How do I do this?](#how-to-test-an-icon-with-the-image-service)
 1. Icons must have been tested with the Image Service's tinting option. [How do I do this?](#how-to-test-an-icon-with-the-image-service)
-1. Icons should have a bounding box of 1024. This is because of a quirk with both versions of the Image Service, whereby a conversion from SVG to PNG will be very blurry if the _source_ SVG has a small viewBox.
+1. Icons should have a bounding box of 1024. This is because of a quirk with the Image Service, whereby a conversion from SVG to PNG will be very blurry if the _source_ SVG has a small viewBox.
 
 
 ### Naming conventions:

--- a/contributing.md
+++ b/contributing.md
@@ -21,7 +21,6 @@ If you want to add or update an icon, please open a pull request, making sure th
 ### Technical:
 
 1. Icons must be SVG v1.1
-1. Icons must not contain any ClipPaths.
 1. Icons must have been run through an SVG compression service (such as [SVGOMG](https://jakearchibald.github.io/svgomg/))
 1. Icons must have been tested with the [Responsive Image Service](https://www.ft.com/__origami/service/image/v2/docs/url-builder)'s SVG -> PNG conversion. [How do I do this?](#how-to-test-an-icon-with-the-image-service)
 1. Icons must have been tested with the Image Service's tinting option. [How do I do this?](#how-to-test-an-icon-with-the-image-service)


### PR DESCRIPTION
As the old image service was retired, we should no longer ask contributors to test their SVGs on it.