### PR TITLE
Add video icon

### DIFF
--- a/svg/video.svg
+++ b/svg/video.svg
@@ -1,0 +1,1 @@
+<svg viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg"><title>Video</title><g fill="#000" fill-rule="evenodd"><path d="M768 304.64v414.72H256V304.64h512zm-460.8 51.301v312.94h409.6V355.94H307.2z" fill-rule="nonzero"/><path d="M604.086 513.28l-142.988-96v192z"/></g></svg>


### PR DESCRIPTION
Icon to represent video content on the site.

**Description:**


**Checklist:**

- [x] Icons must be a single colour (black)
- [x] Icons must be square
- [x] Icons must meet a need that is not already met by a pre-existing icon
- [x] Icons should be suitable for reuse in more than 1 application
- [x] Icons should align to a 40x40 pixel grid, with 10px padding on each side
- [x] Icons should be a solid shape rather than outlines where possible
- [x] Icons should have a minimum line thickness of 2px (including negative space thickness)
- [x] Icons should have square rather than rounded corners where suitable
- [x] Icons must be SVG v1.1
- [x] Icons must have been run through an SVG compression service (such as SVGOMG)
- [x] Icons must have been tested with the Responsive Image Service's SVG -> PNG conversion.
- [x] Icons must have been tested with the Image Service's tinting option.
- [x] Icons should have a bounding box of 1024.
- [x] Icon names must be made up only of lowecase a-z, or a hyphen
- [x] Icon names must include the .svg file extension

---

- [x] Testing PNG conversion using Origami Image Service

---

- [x] Testing PNG + resizing using Origami Image Service

---

- [x] Testing tinting using Origami Image Service
