### PR TITLE
Change node engines requirement to allow major new versions instead of restricting it to the 10.x range

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@financial-times/fticons",
   "version": "1.20.1",
   "engines": {
-    "node": "^10"
+    "node": ">=10"
   },
   "scripts": {
     "build": "oist build-manifest --scheme fticon --source-directory svg --host https://origami-images.ft.com/ --scheme-version $npm_package_version",


### PR DESCRIPTION
**Description:**
The current `^10` node engine means this package can't be used with node 12 etc, which I suspect wasn't intended!