### PR TITLE
make dependabot ignore snyk updates

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -7,3 +7,6 @@ update_configs:
       - match:
           dependency_type: "development"
           update_type: "semver:minor"
+    ignored_updates:
+      - match:
+          dependency_name: "snyk"


### PR DESCRIPTION
snyk does too many updates and it makes for too many pull-requests for origami to review
