### PR TITLE
add scroll-to icon

### DIFF
--- a/svg/edit.svg
+++ b/svg/edit.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 40"><path class="st0" d="M12 25l3 3 15-15-3-3-15 15zM11 26l3 3-4 1z"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1024 1024"><path class="st0" d="M12 25l3 3 15-15-3-3-15 15zM11 26l3 3-4 1z"/></svg>

--- a/svg/edit.svg
+++ b/svg/edit.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1024 1024"><path class="st0" d="M12 25l3 3 15-15-3-3-15 15zM11 26l3 3-4 1z"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 40"><path class="st0" d="M12 25l3 3 15-15-3-3-15 15zM11 26l3 3-4 1z"/></svg>

--- a/svg/scroll-to.svg
+++ b/svg/scroll-to.svg
@@ -1,0 +1,1 @@
+<svg viewBox="0 0 40 40" xmlns="http://www.w3.org/2000/svg"><path fill="#000" fill-rule="nonzero" d="M20 12l6 5.656-1.5 1.414-3.44-3.242V28h-2.12V15.828L15.5 19.07 14 17.656z"/></svg>

--- a/svg/scroll-to.svg
+++ b/svg/scroll-to.svg
@@ -1,1 +1,1 @@
-<svg viewBox="0 0 40 40" xmlns="http://www.w3.org/2000/svg"><path fill="#000" fill-rule="nonzero" d="M20 12l6 5.656-1.5 1.414-3.44-3.242V28h-2.12V15.828L15.5 19.07 14 17.656z"/></svg>
+<svg viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg"><path fill="#000" fill-rule="nonzero" d="M20 12l6 5.656-1.5 1.414-3.44-3.242V28h-2.12V15.828L15.5 19.07 14 17.656z"/></svg>

--- a/svg/scroll-to.svg
+++ b/svg/scroll-to.svg
@@ -1,1 +1,1 @@
-<svg viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg"><path fill="#000" fill-rule="nonzero" d="M20 12l6 5.656-1.5 1.414-3.44-3.242V28h-2.12V15.828L15.5 19.07 14 17.656z"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 40"><path fill="#000" fill-rule="nonzero" d="M20 12l6 5.656-1.5 1.414-3.44-3.242V28h-2.12V15.828L15.5 19.07 14 17.656z"/></svg>


### PR DESCRIPTION
https://financialtimes.slack.com/archives/C01481FKWA2/p1606394177148800

**Josh Wade** said:
> Please can we add this icon to our set? There’s now multiple use cases for it across live blog (app & .com) and app News Feed project.
The intention is for this arrow to represent a ‘scroll-to’ link. Our current arrows inside buttons are used to: show/hide or move backward/forward through pages - hence the need for this. Thank you.

![scroll-to icon](https://user-images.githubusercontent.com/178266/100356191-cfcb6c00-2fea-11eb-9f05-48fb957a8c96.png)


Converted to png:
![arrow](https://www.ft.com/__origami/service/image/v2/images/raw/https://raw.githubusercontent.com/Financial-Times/fticons/scroll-to/svg/scroll-to.svg?source=hoo-hoo&format=png)

Resized to 500px png:
![big arrow](https://www.ft.com/__origami/service/image/v2/images/raw/https://raw.githubusercontent.com/Financial-Times/fticons/scroll-to/svg/scroll-to.svg?source=test&format=png&width=500)

Tinted #ff2a50:
![pink arrow](https://www.ft.com/__origami/service/image/v2/images/raw/https://raw.githubusercontent.com/Financial-Times/fticons/scroll-to/svg/scroll-to.svg?source=test&format=png&tint=ff2a50)
