### PR TITLE
Remove the 0x0x1024x1024 viewport requirement from contributing guide

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,7 +13,6 @@
 - [ ] Icons should have square rather than rounded corners where suitable
 - [ ] Icons must be SVG v1.1
 - [ ] Icons must have been run through an SVG compression service (such as SVGOMG)
-- [ ] Icons should have a bounding box of 1024.
 - [ ] Icon names must be made up only of lowecase a-z, or a hyphen
 - [ ] Icon names must include the .svg file extension
 

--- a/contributing.md
+++ b/contributing.md
@@ -24,8 +24,6 @@ If you want to add or update an icon, please open a pull request, making sure th
 1. Icons must have been run through an SVG compression service (such as [SVGOMG](https://jakearchibald.github.io/svgomg/))
 1. Icons must have been tested with the [Responsive Image Service](https://www.ft.com/__origami/service/image/v2/docs/url-builder)'s SVG -> PNG conversion. [How do I do this?](#how-to-test-an-icon-with-the-image-service)
 1. Icons must have been tested with the Image Service's tinting option. [How do I do this?](#how-to-test-an-icon-with-the-image-service)
-1. Icons should have a bounding box of 1024. This is because of a quirk with the Image Service, whereby a conversion from SVG to PNG will be very blurry if the _source_ SVG has a small viewBox.
-
 
 ### Naming conventions:
 


### PR DESCRIPTION
Cloudinary no longer creates blurry pngs when the source SVG is smol, so we don't need to require the big viewBox anymore.

This will hopefully improve workflow because when the icons come to us from @Financial-Times/designers, they're 40px already :)

For the scroll-to svg, i ran it through svgo, removed the `width/height` attrs and set viewBox to `0 0 40 40` and it was ready.

