### PR TITLE
Add data icon

### DIFF
--- a/svg/data.svg
+++ b/svg/data.svg
@@ -1,0 +1,1 @@
+<svg viewBox="0 0 40 40" xmlns="http://www.w3.org/2000/svg"><path d="M30 10H10v20h20V10zM16.667 21.667h-3.334v5h3.334v-5zm1.666-8.334h3.334v13.334h-3.334V13.333zm8.334 5h-3.334v8.334h3.334v-8.334z" fill="#000" fill-rule="evenodd"/></svg>


### PR DESCRIPTION
Slack: https://financialtimes.slack.com/archives/C01481FKWA2/p1616497505002700
Issue: https://github.com/Financial-Times/o-icons/issues/168

**Description:**


**Checklist:**

- [x] Icons must be a single colour (black)
- [x] Icons must be square
- [x] Icons must meet a need that is not already met by a pre-existing icon
- [x] Icons should be suitable for reuse in more than 1 application
- [x] Icons should align to a 40x40 pixel grid, with 10px padding on each side
- [x] Icons should be a solid shape rather than outlines where possible
- [x] Icons should have a minimum line thickness of 2px (including negative space thickness)
- [x] Icons should have square rather than rounded corners where suitable
- [x] Icons must be SVG v1.1
- [x] Icons must have been run through an SVG compression service (such as SVGOMG)
- [x] Icon names must be made up only of lowecase a-z, or a hyphen
- [x] Icon names must include the .svg file extension

---

[Instructions on how to tests new icons with the Origami Image Service](https://github.com/Financial-Times/fticons/blob/master/contributing.md#how-to-test-an-icon-with-the-image-service)

- [x] Testing PNG conversion using Origami Image Service
- [x] Testing PNG + resizing using Origami Image Service
- [x] Testing tinting using Origami Image Service
